### PR TITLE
[EDX-165] Add descriptions for RestChannel

### DIFF
--- a/descriptions.md
+++ b/descriptions.md
@@ -157,7 +157,7 @@
 
 ## class RestChannel
 
-The `RestChannel` objects is used to interact with a specific channel instance. A channel instance is created or returned by [`channels.get()`]{@link}.
+The `RestChannel` object is used to interact with a specific channel instance. A channel instance is created or returned by [`channels.get()`]{@link}.
 
 | Method / Property | Parameter | Returns | Spec | Description |
 |---|---|---|---|---|


### PR DESCRIPTION
This PR adds descriptions for the RestChannel class. 

All feedback welcome as I thought it made sense to start with one to get the ball rolling, before documenting all classes.

**Note**: `[text-to-display]{@link}` is intended to indicate that the property or parameter should be linked to another class or type when adding it as a docstring comment. If this makes sense I'll add it to the README when I create it. 