### PR TITLE
Add documentation for ClientInformation

### DIFF
--- a/descriptions.md
+++ b/descriptions.md
@@ -1133,3 +1133,14 @@ Contains fields used when referencing a previous message.
 |---|---|---|---|---|
 | timeserial: String || | REX2a | A unique identifier indicating the message being interacted with. |
 | type: String || | REX2b | The reason for interacting with the previous message, for example, `com.ably.reaction` to indicate a reaction. |
+
+## class ClientInformation
+
+Provides information about the Ably client library and the environment in which it’s running.
+
+| Method / Property | Parameter | Returns | Spec | Description |
+|---|---|---|---|---|
+| +agents: Dict<String, String?> || | CR2 | Returns the default key-value entries that the Ably client library uses to identify itself, and the environment in which it’s running, to the Ably service. Its keys are the names of the software components, and its values are their optional versions. The full list of keys that this method might return can be found [here](https://github.com/ably/ably-common/tree/main/protocol#agents). For example, users of the `ably-cocoa` client library can find out the library version by fetching the value for the `"ably-cocoa"` key from the return value of this method. |
+| +agentIdentifier(additionalAgents: Dict<String, String?>?) => String || | CR3 | Returns the `Agent` library identifier. This method should only be used by Ably-authored SDKs. |
+|| `additionalAgents` || CR3c | A set of additional entries for the `Agent` library identifier. Its keys are the names of the agents, and its values are their optional versions. |
+||| `String` | CR3b | The `Agent` library identifier. |


### PR DESCRIPTION
Accurate as of https://github.com/ably/specification/commit/6f67b8443eda3759c129d90f0cdb474ad8db4498. Needs editing by tech writers.

I’m not quite sure how to word the piece of advice about how to check the library version without referring to a specific client library, but I wanted to highlight this use case.