### PR TITLE
Fix terminology used to refer to REST API version

### DIFF
--- a/descriptions.md
+++ b/descriptions.md
@@ -18,7 +18,7 @@ A client that offers a simple stateless API to interact directly with Ably's RES
 | request(String method, String path, Int version, `Dict<String, String>` params?, JsonObject \| JsonArray body?, `Dict<String, String>` headers?) => io HttpPaginatedResponse ||  | RSC19 | Makes a REST request to a provided path. This is provided as a convenience for developers who wish to use REST API functionality that is either not documented or is not yet included in the public API, without having to directly handle features such as authentication, paging, fallback hosts, MsgPack and JSON support. |
 || `method` ||| The request method to use, such as `GET`, `POST`. |
 || `path` ||| The request path. |
-|| `version` || RSC19f1 | The major version of the Ably REST API to use. See the [REST API reference](https://ably.com/docs/api/rest-api#versioning) for information on versioning. |
+|| `version` || RSC19f1 | The version of the Ably REST API to use. See the [REST API reference](https://ably.com/docs/api/rest-api#versioning) for information on versioning. |
 || `params` ||| The parameters to include in the URL query of the request. The parameters depend on the endpoint being queried. See the [REST API reference](https://ably.com/docs/api/rest-api) for the available parameters of each endpoint. |
 || `body` ||| The JSON body of the request. |
 || `headers` ||| Additional HTTP headers to include in the request. |


### PR DESCRIPTION
There is no longer a concept of a "major" version; as of protocol version 2, the protocol version is a single integer (see spec point [CSV2a](https://sdk.ably.com/builds/ably/specification/main/features/#CSV2a)).

Unfortunately, the linked ably.com REST API versioning documentation still refers to API versions 1.1 and 1.2, but that’s a separate issue — the REST API documentation needs to be versioned and updated for newer protocol versions, which Mark says is planned.

Relevant conversation in https://github.com/ably/ably-js/pull/1670#discussion_r1532211929, where Mark says:

> For the docstring I think we can drop "major" and just refer to it as "version" since this will be the case going forwards. We can leave the link in for now too even if it'll be a little wonky until we release the versioned REST API.